### PR TITLE
Allow the scrolling to be disabled again

### DIFF
--- a/code/content.js
+++ b/code/content.js
@@ -21,7 +21,7 @@ var mutation_breaks_scroll_blocker = function (mutation) {
 
 var calendar_observer = new MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
-        if (mutation_breaks_scroll_blocker(mutation)) {
+        if (!mutation_breaks_scroll_blocker(mutation)) {
             disable_scroll();
         }
     });


### PR DESCRIPTION
This should allow the scrolling on Goolge Calendar to be disabled again. This extension no longer works for alot of people. This logic inversion should correct the behavior. 