### PR TITLE
Fix issue where scrolling was not disabled at page load.

### DIFF
--- a/code/content.js
+++ b/code/content.js
@@ -1,29 +1,26 @@
-var calendar_grid_selector = 'div[role="grid"]';
+var calendar_main_selector = 'div[role="main"]';
 var body = document.querySelector('body');
 
-var disable_scroll = function () {
-    for (var live_selector of document.querySelectorAll(calendar_grid_selector)) {
-        live_selector.addEventListener('mousewheel', function (e) {
-            if (e.target.id == 'el') return;
-            e.preventDefault();
-            e.stopPropagation();
-        });
-    }
-};
+var mousewheelHander = function (e) {
+    if (e.target.id == 'el')
+        return;
+    e.preventDefault();
+    e.stopPropagation();
+}
 
-var mutation_breaks_scroll_blocker = function (mutation) {
-    if (mutation.attributeName && mutation.attributeName == 'data-viewfamily') {
-        if (body.getAttribute('data-viewfamily') == 'EVENT')
-            return true;
+var disable_scroll = function () {
+    for (var live_selector of document.querySelectorAll(calendar_main_selector)) {
+        // Remove the event handler before adding a new one to make sure
+        // we don't have multiple event handlers registered.
+        live_selector.removeEventListener('mousewheel', mousewheelHander, true);
+        live_selector.addEventListener('mousewheel', mousewheelHander, true);
     }
 };
 
 var calendar_observer = new MutationObserver(function (mutations) {
-    mutations.forEach(function (mutation) {
-        if (mutation_breaks_scroll_blocker(mutation)) {
-            disable_scroll();
-        }
-    });
+    // A change on the webpage may replace the "main" div, so we need to
+    // re-register the event handler.
+    disable_scroll();
 });
 calendar_observer.observe(body, {attributes: true});
 

--- a/code/content.js
+++ b/code/content.js
@@ -36,3 +36,9 @@ var observe_if_calendar_available = function () {
 };
 
 observe_if_calendar_available();
+
+// Disable scrolling once at startup.
+// Note that the data-viewfamily mutation doesn't occur when the page is loaded.
+// Rather, the data-viewfamily mutation only occurs when the user changes views.
+// Thus, we need to disable scrolling once when the page is initially loaded.
+disable_scroll();

--- a/code/content.js
+++ b/code/content.js
@@ -21,7 +21,7 @@ var mutation_breaks_scroll_blocker = function (mutation) {
 
 var calendar_observer = new MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
-        if (!mutation_breaks_scroll_blocker(mutation)) {
+        if (mutation_breaks_scroll_blocker(mutation)) {
             disable_scroll();
         }
     });

--- a/code/content.js
+++ b/code/content.js
@@ -1,6 +1,5 @@
 var calendar_grid_selector = 'div[role="grid"]';
 var body = document.querySelector('body');
-var calendar_grid = document.querySelectorAll(calendar_grid_selector);
 
 var disable_scroll = function () {
     for (var live_selector of document.querySelectorAll(calendar_grid_selector)) {
@@ -26,19 +25,7 @@ var calendar_observer = new MutationObserver(function (mutations) {
         }
     });
 });
+calendar_observer.observe(body, {attributes: true});
 
-var observe_if_calendar_available = function () {
-    if (!calendar_grid) {
-        window.setTimeout(observe_if_calendar_available, 500);
-        return;
-    }
-    calendar_observer.observe(body, {attributes: true});
-};
-
-observe_if_calendar_available();
-
-// Disable scrolling once at startup.
-// Note that the data-viewfamily mutation doesn't occur when the page is loaded.
-// Rather, the data-viewfamily mutation only occurs when the user changes views.
-// Thus, we need to disable scrolling once when the page is initially loaded.
+// Disable scrolling once at startup just in case no mutations occur at page load.
 disable_scroll();


### PR DESCRIPTION
After a recent update to Google Calendar, the scrolling was still enabled when the page loaded (see #11 ).  However, the scrolling was properly disabled after the user changed to a different view.

An initial fix was proposed in #12 which was functional, but that doesn't address the root of the problem. Also, the original fix might have a performance impact, since it registers extra "mousewheel" event listeners.

The issue was that the data-viewfamily mutation no longer occurs when the page is loaded.
Now, the data-viewfamily mutation only occurs when the user changes views.
Thus, we need to disable scrolling once when the page is initially loaded.
