### PR TITLE
Fix google calendar update

### DIFF
--- a/code/content.js
+++ b/code/content.js
@@ -1,6 +1,7 @@
-var calendar_grid_selector = 'div[role="grid"]';
 var body = document.querySelector('body');
+var calendar_grid_selector = 'div[role="grid"]';
 var calendar_grid = document.querySelectorAll(calendar_grid_selector);
+var element_to_observe = document.querySelector('div[class="BXL82c"]');
 
 var disable_scroll = function () {
     for (var live_selector of document.querySelectorAll(calendar_grid_selector)) {
@@ -19,7 +20,7 @@ var mutation_breaks_scroll_blocker = function (mutation) {
     }
 };
 
-var calendar_observer = new MutationObserver(function (mutations) {
+var overlay_observer = new MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
         if (mutation_breaks_scroll_blocker(mutation)) {
             disable_scroll();
@@ -27,12 +28,17 @@ var calendar_observer = new MutationObserver(function (mutations) {
     });
 });
 
+var calendar_observer = new MutationObserver(function (mutations) {
+    disable_scroll();
+});
+
 var observe_if_calendar_available = function () {
     if (!calendar_grid) {
         window.setTimeout(observe_if_calendar_available, 500);
         return;
     }
-    calendar_observer.observe(body, {attributes: true});
+    overlay_observer.observe(body, {attributes: true});
+    calendar_observer.observe(element_to_check, {childList: true});
 };
 
 observe_if_calendar_available();

--- a/code/content.js
+++ b/code/content.js
@@ -14,10 +14,7 @@ var disable_scroll = function () {
 };
 
 var mutation_breaks_scroll_blocker = function (mutation) {
-    if (mutation.attributeName && mutation.attributeName == 'data-viewfamily') {
-        if (body.getAttribute('data-viewfamily') == 'EVENT')
-            return true;
-    }
+    return (mutation.attributeName && mutation.attributeName == 'data-viewfamily' && body.getAttribute('data-viewfamily') == 'EVENT');
 };
 
 var overlay_observer = new MutationObserver(function (mutations) {
@@ -38,7 +35,7 @@ var observe_if_calendar_available = function () {
         return;
     }
     overlay_observer.observe(body, {attributes: true});
-    calendar_observer.observe(element_to_check, {childList: true});
+    calendar_observer.observe(element_to_observe, {childList: true});
 };
 
 observe_if_calendar_available();


### PR DESCRIPTION
Added a new Mutation Observer to specifically monitor changes in the Date Field in the Header area. This change is necessary as Google Calendar has changed some of the DOM structure and the way how it's loaded. 
Using div[class="BXL82c"] as the selector for the element to observe for changes could prove to be unreliable when Google will make further changes, but I could not find other elements to check for as most of the page content is destroyed and recreated on each change of the calendar-view.